### PR TITLE
Fix div-by-zero errors on files which don't have any changed content

### DIFF
--- a/src/Squirrel/BinaryPatchUtility.cs
+++ b/src/Squirrel/BinaryPatchUtility.cs
@@ -230,10 +230,13 @@ namespace Squirrel.Bsdiff
             WriteInt64(controlEndPosition - startPosition - c_headerSize, header, 8);
 
             // write compressed diff data
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            if (dblen > 0)
             {
-                bz2Stream.Write(db, 0, dblen);
+                using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+                using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+                {
+                    bz2Stream.Write(db, 0, dblen);
+                }
             }
 
             // compute size of compressed diff data
@@ -241,10 +244,13 @@ namespace Squirrel.Bsdiff
             WriteInt64(diffEndPosition - controlEndPosition, header, 16);
 
             // write compressed extra data
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            if (eblen > 0)
             {
-                bz2Stream.Write(eb, 0, eblen);
+                using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+                using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+                {
+                    bz2Stream.Write(eb, 0, eblen);
+                }
             }
 
             // seek to the beginning, write the header, then seek back to end


### PR DESCRIPTION
Copy of https://github.com/Squirrel/Squirrel.Windows/pull/1361
> There are cases where the length in write operations becomes zero, at which point this code will throw an exception and fail to create bsdiff deltas.
> 
> As this is critical to our production workflow, it has been temporarily published as ppy.Squirrel.windows (along with several other PRs that are not merged into official releases yet).
> 
> Test files which cause the issue to reproduce (large): https://www.dropbox.com/sh/p13oiqir02xzny1/AABUHNZeP2u2T-AjViFYCG6na?dl=0