### PR TITLE
Fix condition to ignore .diff files when .vcdiff exists

### DIFF
--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -129,7 +129,7 @@ namespace Squirrel
                     .Where(x => x.StartsWith("lib", StringComparison.InvariantCultureIgnoreCase))
                     .Where(x => !x.EndsWith(".shasum", StringComparison.InvariantCultureIgnoreCase))
                     .Where(x => !x.EndsWith(".diff", StringComparison.InvariantCultureIgnoreCase) ||
-                                !deltaPathRelativePaths.Contains(x.Replace(".diff", ".bsdiff")) ||
+                                !deltaPathRelativePaths.Contains(x.Replace(".diff", ".bsdiff")) &&
                                 !deltaPathRelativePaths.Contains(x.Replace(".diff", ".vcdiff")))
                     .ForEach(file => {
                         pathsVisited.Add(Regex.Replace(file, diffFileRegex, "").ToLowerInvariant());


### PR DESCRIPTION
If a ".vcdiff" file exists, ignore the parallel ".diff" file (which exists only for backward compatibility reasons).
Similar to https://github.com/AurorNZ/Squirrel.Windows/commit/6897593bae8b1bfc33ae9b9cc4dab65328092fdc